### PR TITLE
feat: create FastAPI app with GET / and POST endpoints

### DIFF
--- a/ai-service/app/main.py
+++ b/ai-service/app/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+#request model
+class MatchRequest(BaseModel):
+    resume: str = Field(min_length=1)
+    jd: str = Field(min_length=1)
+
+#response model
+class MatchResponse(BaseModel):
+    similarity_score: float
+
+@app.post("/match", response_model=MatchResponse)
+async def match(req: MatchRequest):
+    if not req.resume.strip() or not req.jd.strip():
+        raise HTTPException(status_code=400, detail="Resume and job description must be non-empty")
+    
+    # Temporary stub value — AI service would compute a real score
+    return MatchResponse(similarity_score=0.42)

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.0
+pydantic==2.7.1


### PR DESCRIPTION
## What
- Created initial FastAPI service under `ai-service/app/main.py`
- Added `/` endpoint to test the service and return "Hello World"
- Added `/match` stub endpoint (accepts resume + job description text, returns dummy score)

## Why
This sets up the AI service that will eventually run the similarity model.
The `/match` endpoint defines the contract the Node API will call later.

## How to test
1. Run `uvicorn app.main:app --reload` inside the `ai-service` folder
2. Visit `http://localhost:8000/` → should return `{"message": "Hello World"}`
3. Use Postman to send a POST to `http://localhost:8000/match` with JSON:
   ```json
   {
     "resume": "some text",
     "jd": "some text"
   }
