### PR TITLE
feat: write indexer to embed seed resume data and write to postgres db; add…

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,9 @@
+# Postgres connection (for Python indexer, FastAPI, Node)
+PGHOST=localhost
+PGPORT=5432
+PGDATABASE=resumes
+PGUSER=app
+PGPASSWORD=CHANGEME
+
+# FastAPI service base URL (so Node knows where to call)
+AI_BASE_URL=http://localhost:8000

--- a/ai-service/scripts/index_resumes.py
+++ b/ai-service/scripts/index_resumes.py
@@ -1,0 +1,68 @@
+import json
+import os
+import requests
+import psycopg2
+from psycopg2.extras import execute_values
+
+AI_BASE_URL = os.getenv("AI_BASE_URL", "http://localhost:8000")
+
+# Postgres connection info - tries to read from env vars, otherwise uses defaults from docker-compose
+DB = {
+    "host": os.getenv("PGHOST", "localhost"),
+    "port": int(os.getenv("PGPORT", "5432")),
+    "dbname": os.getenv("PGDATABASE", "resume_db"),
+    "user": os.getenv("PGUSER", "app"),
+    "password": os.getenv("PGPASSWORD", "app"),
+}
+
+SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "data", "seed", "resumes_data.jsonl")
+SEED_PATH = os.path.abspath(SEED_PATH)
+
+# calls AI service to get embedding for given text
+def embed(text: str) -> list[float]:
+    r = requests.post(f"{AI_BASE_URL}/embed", json={"text": text})
+    r.raise_for_status()
+    return r.json()["embedding"]
+
+
+# reads resumes from seed file, gets embeddings from AI service, and inserts into Postgres
+def main():
+    # read lines from seed file
+    with open(SEED_PATH, "r", encoding="utf-8") as f:
+        rows = [json.loads(line) for line in f if line.strip()]
+
+    # connect to db
+    conn = psycopg2.connect(**DB)
+    conn.autocommit = False
+    cur = conn.cursor()
+    try:
+        #loop through rows in seed file
+        for row in rows:
+            # insert into resumes table
+            cur.execute(
+                "INSERT INTO resumes(candidate_id, text) VALUES (%s, %s) RETURNING id",
+                (row["candidate_id"], row["text"])
+            )
+            resume_id = cur.fetchone()[0]
+            # get embedding for this resume
+            vec = embed(row["text"]) 
+
+            # insert embedding into resume_embeddings table
+            cur.execute(
+                "INSERT INTO resume_embeddings(resume_id, embedding) VALUES (%s, %s)",
+                (resume_id, vec)
+            )
+            print(f"Inserted resume {row['candidate_id']} with id {resume_id}")
+
+        conn.commit()
+        print(f"Indexed {len(rows)} resumes.")
+    except Exception:
+        conn.rollback()
+        print("Error occurred, transaction rolled back:", e)
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+if __name__ == "__main__":
+    main()

--- a/data/seed/resumes_data.jsonl
+++ b/data/seed/resumes_data.jsonl
@@ -1,0 +1,8 @@
+{"candidate_id":"cand-001","text":"Backend engineer with Python, FastAPI, AWS, Docker. Built REST APIs and deployed to ECS."}
+{"candidate_id":"cand-002","text":"iOS engineer experienced in Swift, UIKit, Combine, and App Store releases."}
+{"candidate_id":"cand-003","text":"Data scientist focused on NLP, PyTorch, scikit-learn, and model deployment."}
+{"candidate_id":"cand-004","text":"Frontend developer with React, TypeScript, Node, and accessibility best practices."}
+{"candidate_id":"cand-005","text":"ML engineer building recommendation systems, feature pipelines, and MLOps on Kubernetes."}
+{"candidate_id":"cand-006","text":"DevOps engineer with Terraform, CI/CD, GitHub Actions, and observability tooling."}
+{"candidate_id":"cand-007","text":"Backend engineer, Java/Spring Boot, PostgreSQL, Kafka, microservices."}
+{"candidate_id":"cand-008","text":"Full-stack engineer with Next.js, Express, Prisma, and AWS serverless."}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  db:
+    image: pgvector/pgvector:pg16   # Postgres 16 with pgvector
+    container_name: resume_pg
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: resume_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/infra/schema.sql
+++ b/infra/schema.sql
@@ -1,0 +1,26 @@
+-- Enable pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS resumes (
+  id SERIAL PRIMARY KEY,
+  candidate_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- 384 dims because MiniLM embeddings are 384-length
+CREATE TABLE IF NOT EXISTS resume_embeddings (
+  resume_id INT PRIMARY KEY REFERENCES resumes(id) ON DELETE CASCADE,
+  embedding VECTOR(384) -- vector data
+);
+
+-- create an index on the data for faster retrieval
+CREATE INDEX IF NOT EXISTS idx_resume_embedding
+ON resume_embeddings
+USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+
+SELECT * FROM resumes;
+SELECT resume_id, embedding[1:5] AS sample_dims
+FROM resume_embeddings
+LIMIT 10;

--- a/node-api/index.js
+++ b/node-api/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const AI_BASE_URL = 'http://localhost:8000'; // Base URL of your FastAPI service
+const AI_BASE_URL = process.env.AI_BASE_URL || 'http://localhost:8000'; // Base URL of your FastAPI service
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
### Goal
Learn how to connect AI models with a database for semantic search

### Activities (& why they're important) 

- Activity: Wrote `index_resumes_simple.py` to accept seed data of fake resumes from `resumes.jsonl` and insert each into Postgres database.
_→ Takeaway: Writing Python scripts that interact with a relational database.__

- Activity: Called the FastAPI /embed endpoint from the indexer instead of reloading the model inside the script.
_→ Takeaway: Microservice pattern (i.e., separating responsibilities across services) keeps logic centralized._

- Activity: Defined a `resume_embeddings` table with a `pgvector` column and created an IVFFLAT index in `schema.sql`.
_→ Takeaway: Learned how vector databases enable similarity search and how indexing strategies (like IVFFLAT) make semantic queries scalable._

- Activity: Added .env.example and refactored the indexer to pull DB credentials from environment variables.
_→ Takeaway: Practiced secure configuration management to ensure secrets are never be hardcoded into scripts / pushed to GH_